### PR TITLE
updated cdn address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 help_dialog.html
 src/functions/gen/*.ts
 .vscode/
+pnpm-lock.yaml

--- a/src/aws_data_loader.ts
+++ b/src/aws_data_loader.ts
@@ -5,7 +5,7 @@ interface AwsDataLoaderTransform {
 }
 
 export class AwsDataLoader {
-    static readonly baseHost = 'https://a0.p.awsstatic.com'
+    static readonly baseHost = 'https://cdn.x.macroscope.io/aws-pricing/retro'
     static readonly expireTimeSeconds = 3600
 
     private readonly cache: CacheLoader


### PR DESCRIPTION
Old aws api address was not working anymore. 
Macroscope.io decided to host its own CDN. We will start to use same structure for the existing formula's